### PR TITLE
Fix the build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--plugin>
+            <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>${asciidoctor.version}</version>
@@ -219,7 +219,7 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin-->
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
The build was broken when running from a clean checkout. Some part of the build process depends on asciidoc having been run to generate boilerplate documentation.