### PR TITLE
Make sure our TGT is renewed correctly

### DIFF
--- a/src/main/java/uk/co/amrc/factoryplus/Attempt.java
+++ b/src/main/java/uk/co/amrc/factoryplus/Attempt.java
@@ -1,0 +1,146 @@
+/* Factory+ Java client library.
+ * Value-or-error monad
+ * Copyright 2023 AMRC.
+ */
+
+package uk.co.amrc.factoryplus;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.functions.Supplier;
+import io.reactivex.rxjava3.core.Single;
+
+public abstract class Attempt<T> {
+    public static <T> Attempt<T> of (T value)
+    {
+        Objects.requireNonNull(value);
+        return new AttemptSuccess<T>(value);
+    }
+    public static <T> Attempt<T> ofError (Throwable error)
+    {
+        Objects.requireNonNull(error);
+        return new AttemptFailure<T>(error);
+    }
+
+    public static <T> Attempt<T> create (Supplier<Attempt<T>> fn)
+    {
+        Objects.requireNonNull(fn);
+        try {
+            return fn.get();
+        }
+        catch (Throwable err) {
+            return Attempt.ofError(err);
+        }
+    }
+    public static <T> Attempt<T> ofSupplier (Supplier<T> fn)
+    {
+        Objects.requireNonNull(fn);
+        return Attempt.create(() -> Attempt.of(fn.get()));
+    }
+    public static <T> Attempt<T> ofCallable (Callable<T> fn)
+    {
+        Objects.requireNonNull(fn);
+        return Attempt.create(() -> Attempt.of(fn.call()));
+    }
+
+    public abstract boolean isPresent ();
+    public abstract boolean isError ();
+    public abstract T get ();
+    public abstract Throwable getError ();
+    public abstract T orElse (java.util.function.Function<Throwable,T> fn);
+    public abstract T orElseThrow () throws Throwable;
+
+    public abstract <R> Attempt<R> flatMap (Function<T,Attempt<R>> fn);
+    public abstract <R> Attempt<R> map (Function<T,R> fn);
+    public abstract Attempt<T> or (Function<Throwable,Attempt<T>> fn);
+    public abstract <E> Attempt<T> handle (
+        Class<E> cls, Function<E,Attempt<T>> fn);
+    public abstract <E> Attempt<T> mapError (
+        Class<E> cls, Function<E,Throwable> fn);
+
+    public abstract Single<T> toSingle ();
+}
+
+class AttemptSuccess<T> extends Attempt<T> {
+    private T value;
+
+    public AttemptSuccess (T value)
+    {
+        this.value = value;
+    }
+
+    public boolean isPresent () { return true; }
+    public boolean isError () { return false; }
+
+    public T get () { return value; }
+    public Throwable getError () { throw new NoSuchElementException(); }
+    public T orElse (java.util.function.Function<Throwable,T> fn) {
+        return value;
+    }
+    public T orElseThrow () throws Throwable { return value; }
+
+    public <R> Attempt<R> flatMap (Function<T,Attempt<R>> fn)
+    {
+        Objects.requireNonNull(fn);
+        return Attempt.create(() -> fn.apply(value));
+    }
+    public <R> Attempt<R> map (Function<T,R> fn)
+    {
+        Objects.requireNonNull(fn);
+        return this.flatMap(v -> Attempt.of(fn.apply(v)));
+    }
+    public Attempt<T> or (Function<Throwable,Attempt<T>> fn) { return this; }
+    public <E> Attempt<T> handle (Class<E> cls, Function<E,Attempt<T>> fn) 
+        { return this; }
+    public <E> Attempt<T> mapError (Class<E> cls, Function<E,Throwable> fn)
+        { return this; }
+
+    public Single<T> toSingle () { return Single.just(value); }
+}
+
+class AttemptFailure<T> extends Attempt<T> {
+    private Throwable error;
+
+    public AttemptFailure (Throwable error)
+    {
+        this.error = error;
+    }
+
+    public boolean isPresent () { return false; }
+    public boolean isError () { return true; }
+
+    public T get () { throw new NoSuchElementException(error); }
+    public Throwable getError () { return error; }
+    public T orElse (java.util.function.Function<Throwable,T> fn) {
+        return fn.apply(error);
+    }
+    public T orElseThrow () throws Throwable { throw error; }
+
+    public <R> Attempt<R> flatMap (Function<T,Attempt<R>> fn)
+    {
+        return Attempt.<R>ofError(error);
+    }
+    public <R> Attempt<R> map (Function<T,R> fn)
+    {
+        return Attempt.<R>ofError(error);
+    }
+    public Attempt<T> or (Function<Throwable,Attempt<T>> fn)
+    {
+        return Attempt.create(() -> fn.apply(error));
+    }
+    public <E> Attempt<T> handle (Class<E> cls, Function<E,Attempt<T>> fn)
+    {
+        if (!cls.isInstance(error)) return this;
+        return Attempt.create(() -> fn.apply(cls.cast(error)));
+    }
+    public <E> Attempt<T> mapError (Class<E> cls, Function<E,Throwable> fn)
+    {
+        return handle(cls, e -> 
+            Attempt.<T>ofError(fn.apply(cls.cast(e))));
+    }
+
+    public Single<T> toSingle () { return Single.error(error); }
+}

--- a/src/main/java/uk/co/amrc/factoryplus/FPServiceClient.java
+++ b/src/main/java/uk/co/amrc/factoryplus/FPServiceClient.java
@@ -181,10 +181,9 @@ public class FPServiceClient {
     synchronized public FPGssServer gssServer ()
     {
         if (_gss_server == null) {
-            String princ = getConf("server_principal");
             String keytab = getConf("server_keytab");
 
-            _gss_server = gss().server(princ, keytab);
+            _gss_server = gss().server("*", keytab);
         }
 
         return _gss_server;

--- a/src/main/java/uk/co/amrc/factoryplus/gss/FPGssClient.java
+++ b/src/main/java/uk/co/amrc/factoryplus/gss/FPGssClient.java
@@ -26,41 +26,20 @@ import org.slf4j.LoggerFactory;
 import org.ietf.jgss.*;
 import org.json.*;
 
+import uk.co.amrc.factoryplus.Attempt;
+
 /** GSS client credentials.
  */
-public class FPGssClient extends FPGssPrincipal {
+public abstract class FPGssClient extends FPGssPrincipal {
     private static final Logger log = LoggerFactory.getLogger(FPGssServer.class);
 
-    //private GSSCredential creds;
-
     /** Internal, construct via {@link FPGssProvider}. */
-    public FPGssClient (FPGssProvider provider, Subject subject)
+    public FPGssClient (FPGssProvider provider)
     {
-        super(provider, subject);
+        super(provider);
     }
 
-    /** Fetches credentials.
-     *
-     * This performs a Kerberos login, if necessary, and verifies we can
-     * access a usable ccache.
-     *
-     * @return This, iff we are successful in getting creds.
-     */
-    public Optional<FPGssClient> login ()
-    {
-        return Optional.of(this);
-
-//        return withSubject("getting client credentials", () -> {
-//
-//            log.info("Got GSS creds for client:");
-//            for (Oid mech : creds.getMechs()) {
-//                log.info("  Oid {}, name {}", 
-//                    mech, creds.getName(mech));
-//            }
-//
-//            return this;
-//        });
-    }
+    protected int getCredUsage () { return GSSCredential.INITIATE_ONLY; }
 
     /** Creates a GSS initiator context.
      *
@@ -69,7 +48,7 @@ public class FPGssClient extends FPGssPrincipal {
      * @param server The server we are communicating with.
      * @return A GSS context.
      */
-    public Optional<GSSContext> createContext (String server)
+    public Attempt<GSSContext> createContext (String server)
     {
         return _createContext(server, provider.krb5PrincipalNT());
     }
@@ -83,19 +62,17 @@ public class FPGssClient extends FPGssPrincipal {
      * @param service The server we are communicating with.
      * @return A GSS context.
      */
-    public Optional<GSSContext> createContextHB (String service)
+    public Attempt<GSSContext> createContextHB (String service)
     {
         return _createContext(service, GSSName.NT_HOSTBASED_SERVICE);
     }
 
-    private Optional<GSSContext> _createContext (String name, Oid type)
+    private Attempt<GSSContext> _createContext (String name, Oid type)
     {
-        return withSubject("creating client context", () -> {
+        return withCreds(creds -> {
             GSSManager mgr = provider.getGSSManager();
             Oid mech = provider.krb5Mech();
 
-            GSSCredential creds = mgr
-                .createCredential(GSSCredential.INITIATE_ONLY);
             GSSName srv_nam = mgr.createName(name, type, mech);
 
             return mgr.createContext(

--- a/src/main/java/uk/co/amrc/factoryplus/gss/FPGssClient.java
+++ b/src/main/java/uk/co/amrc/factoryplus/gss/FPGssClient.java
@@ -31,7 +31,7 @@ import org.json.*;
 public class FPGssClient extends FPGssPrincipal {
     private static final Logger log = LoggerFactory.getLogger(FPGssServer.class);
 
-    private GSSCredential creds;
+    //private GSSCredential creds;
 
     /** Internal, construct via {@link FPGssProvider}. */
     public FPGssClient (FPGssProvider provider, Subject subject)
@@ -59,18 +59,18 @@ public class FPGssClient extends FPGssPrincipal {
      */
     public Optional<FPGssClient> login ()
     {
-        return withSubject("getting client credentials", () -> {
-            creds = provider.getGSSManager()
-                .createCredential(GSSCredential.INITIATE_ONLY);
+        return Optional.of(this);
 
-            log.info("Got GSS creds for client:");
-            for (Oid mech : creds.getMechs()) {
-                log.info("  Oid {}, name {}", 
-                    mech, creds.getName(mech));
-            }
-
-            return this;
-        });
+//        return withSubject("getting client credentials", () -> {
+//
+//            log.info("Got GSS creds for client:");
+//            for (Oid mech : creds.getMechs()) {
+//                log.info("  Oid {}, name {}", 
+//                    mech, creds.getName(mech));
+//            }
+//
+//            return this;
+//        });
     }
 
     /** Creates a GSS initiator context.
@@ -102,9 +102,13 @@ public class FPGssClient extends FPGssPrincipal {
     private Optional<GSSContext> _createContext (String name, Oid type)
     {
         return withSubject("creating client context", () -> {
-            Oid mech = provider.krb5Mech();
             GSSManager mgr = provider.getGSSManager();
+            Oid mech = provider.krb5Mech();
+
+            GSSCredential creds = mgr
+                .createCredential(GSSCredential.INITIATE_ONLY);
             GSSName srv_nam = mgr.createName(name, type, mech);
+
             return mgr.createContext(
                 srv_nam, mech, creds, GSSContext.DEFAULT_LIFETIME);
         });

--- a/src/main/java/uk/co/amrc/factoryplus/gss/FPGssClient.java
+++ b/src/main/java/uk/co/amrc/factoryplus/gss/FPGssClient.java
@@ -39,17 +39,6 @@ public class FPGssClient extends FPGssPrincipal {
         super(provider, subject);
     }
 
-    public String getPrincipal ()
-    {
-        try {
-            return creds.getName(provider.krb5Mech()).toString();
-        }
-        catch (GSSException e) {
-            throw new ServiceConfigurationError(
-                "Can't read GSS principal name", e);
-        }
-    }
-
     /** Fetches credentials.
      *
      * This performs a Kerberos login, if necessary, and verifies we can

--- a/src/main/java/uk/co/amrc/factoryplus/gss/FPGssClientCcache.java
+++ b/src/main/java/uk/co/amrc/factoryplus/gss/FPGssClientCcache.java
@@ -1,0 +1,41 @@
+/* Factory+ Java client library.
+ * GSS client with ccache.
+ * Copyright 2023 AMRC.
+ */
+
+package uk.co.amrc.factoryplus.gss;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceConfigurationError;
+import java.util.concurrent.Callable;
+import java.util.stream.Stream;
+import java.util.stream.Collectors;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.*;
+import javax.security.auth.login.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.ietf.jgss.*;
+import org.json.*;
+
+import uk.co.amrc.factoryplus.Attempt;
+
+public class FPGssClientCcache extends FPGssClient {
+    public FPGssClientCcache (FPGssProvider provider)
+    {
+        super(provider);
+    }
+
+    protected LoginContext buildLoginContext (Subject subj)
+        throws LoginException
+    {
+        Configuration config = new KrbConfiguration();
+        CallbackHandler cb = new NullCallbackHandler();
+        return new LoginContext("client-ccache", subj, cb, config);
+    }
+}

--- a/src/main/java/uk/co/amrc/factoryplus/gss/FPGssClientKeytab.java
+++ b/src/main/java/uk/co/amrc/factoryplus/gss/FPGssClientKeytab.java
@@ -1,0 +1,34 @@
+/* Factory+ Java client library.
+ * GSS client with ccache.
+ * Copyright 2023 AMRC.
+ */
+
+package uk.co.amrc.factoryplus.gss;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.*;
+import javax.security.auth.login.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FPGssClientKeytab extends FPGssClient {
+    private String principal;
+    private String keytab;
+
+    public FPGssClientKeytab (FPGssProvider provider,
+        String principal, String keytab)
+    {
+        super(provider);
+        this.principal = principal;
+        this.keytab = keytab;
+    }
+
+    protected LoginContext buildLoginContext (Subject subj)
+        throws LoginException
+    {
+        Configuration config = new KrbConfiguration(principal, keytab);
+        CallbackHandler cb = new NullCallbackHandler();
+        return new LoginContext("client-keytab", subj, cb, config);
+    }
+}

--- a/src/main/java/uk/co/amrc/factoryplus/gss/FPGssClientPassword.java
+++ b/src/main/java/uk/co/amrc/factoryplus/gss/FPGssClientPassword.java
@@ -1,0 +1,34 @@
+/* Factory+ Java client library.
+ * GSS client with ccache.
+ * Copyright 2023 AMRC.
+ */
+
+package uk.co.amrc.factoryplus.gss;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.*;
+import javax.security.auth.login.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FPGssClientPassword extends FPGssClient {
+    private String principal;
+    private char[] password;
+
+    public FPGssClientPassword (FPGssProvider provider,
+        String principal, char[] password)
+    {
+        super(provider);
+        this.principal = principal;
+        this.password = password;
+    }
+
+    protected LoginContext buildLoginContext (Subject subj)
+        throws LoginException
+    {
+        Configuration config = new KrbConfiguration();
+        CallbackHandler cb = new PasswordCallbackHandler(principal, password);
+        return new LoginContext("client-password", subj, cb, config);
+    }
+}

--- a/src/main/java/uk/co/amrc/factoryplus/gss/FPGssPrincipal.java
+++ b/src/main/java/uk/co/amrc/factoryplus/gss/FPGssPrincipal.java
@@ -41,12 +41,6 @@ public abstract class FPGssPrincipal {
         this.subject = subject;
     }
 
-    /** Gets our Kerberos principal name.
-     *
-     * @return Our Kerberos principal name.
-     */
-    public abstract String getPrincipal ();
-
     /** Performs an operation using our Subject.
      *
      * We hold an internal {@link Subject} representing our security

--- a/src/main/java/uk/co/amrc/factoryplus/gss/FPGssPrincipal.java
+++ b/src/main/java/uk/co/amrc/factoryplus/gss/FPGssPrincipal.java
@@ -60,7 +60,7 @@ public abstract class FPGssPrincipal {
             return Optional.of(Subject.doAs(subject, action));
         }
         catch (PrivilegedActionException e) {
-            log.error(msg, e.toString());
+            log.error(msg, e);
             return Optional.<T>empty();
         }
     }

--- a/src/main/java/uk/co/amrc/factoryplus/gss/FPGssProvider.java
+++ b/src/main/java/uk/co/amrc/factoryplus/gss/FPGssProvider.java
@@ -94,6 +94,14 @@ public class FPGssProvider {
         return buildSubject("client-password", cb, config);
     }
 
+    public Optional<Subject> buildClientSubjectWithKeytab (
+        String keytab, String principal)
+    {
+        Configuration config = new KrbConfiguration(principal, keytab);
+        CallbackHandler cb = new NullCallbackHandler();
+        return buildSubject("client-keytab", cb, config);
+    }
+
     /** Builds server (acceptor) credentials.
      *
      * The <code>FPGssServer</code> returned from this method will
@@ -119,6 +127,21 @@ public class FPGssProvider {
     public Optional<FPGssClient> clientWithCcache ()
     {
         return buildClientSubjectWithCcache()
+            .map(subj -> new FPGssClient(this, subj));
+    }
+
+    /** Builds client (initiator) creds from a keytab.
+     *
+     * This performs a new Kerberos login using the keytab.
+     *
+     * @param principal The principal to use.
+     * @param keytab The keytab file to use.
+     * @return The client credentials.
+     */
+    public Optional<FPGssClient> clientWithKeytab (
+        String principal, String keytab)
+    {
+        return buildClientSubjectWithKeytab(keytab, principal)
             .map(subj -> new FPGssClient(this, subj));
     }
 

--- a/src/main/java/uk/co/amrc/factoryplus/gss/FPGssServer.java
+++ b/src/main/java/uk/co/amrc/factoryplus/gss/FPGssServer.java
@@ -30,7 +30,7 @@ public class FPGssServer extends FPGssPrincipal {
     private static final Logger log = LoggerFactory.getLogger(FPGssServer.class);
 
     String principal;
-    private GSSCredential creds;
+    //private GSSCredential creds;
 
     /** Internal; construct via {@link FPGssProvider}. */
     public FPGssServer (FPGssProvider provider, String principal, Subject subject)
@@ -49,18 +49,18 @@ public class FPGssServer extends FPGssPrincipal {
      */
     public Optional<FPGssServer> login ()
     {
-        return withSubject("getting creds from keytab", () -> {
-            creds = provider.getGSSManager()
-                .createCredential(GSSCredential.ACCEPT_ONLY);
+        return Optional.of(this);
 
-            log.info("Got GSS creds for server:");
-            for (Oid mech : creds.getMechs()) {
-                log.info("  Oid {}, name {}", 
-                    mech, creds.getName(mech));
-            }
-
-            return this;
-        });
+//        return withSubject("getting creds from keytab", () -> {
+//
+//            log.info("Got GSS creds for server:");
+//            for (Oid mech : creds.getMechs()) {
+//                log.info("  Oid {}, name {}", 
+//                    mech, creds.getName(mech));
+//            }
+//
+//            return this;
+//        });
     }
 
     /** Creates a GSS context.
@@ -69,7 +69,11 @@ public class FPGssServer extends FPGssPrincipal {
      */
     public Optional<GSSContext> createContext ()
     {
-        return withSubject("creating server context",
-                () -> provider.getGSSManager().createContext(creds));
+        return withSubject("creating server context", () -> {
+            GSSManager mgr = provider.getGSSManager();
+            GSSCredential creds = mgr
+                .createCredential(GSSCredential.ACCEPT_ONLY);
+            return mgr.createContext(creds);
+        });
     }
 }

--- a/src/main/java/uk/co/amrc/factoryplus/gss/FPGssServer.java
+++ b/src/main/java/uk/co/amrc/factoryplus/gss/FPGssServer.java
@@ -5,7 +5,6 @@
 
 package uk.co.amrc.factoryplus.gss;
 
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -14,8 +13,6 @@ import java.util.concurrent.Callable;
 import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
-import java.security.PrivilegedExceptionAction;
-import java.security.PrivilegedActionException;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.*;
 import javax.security.auth.login.*;
@@ -26,54 +23,45 @@ import org.slf4j.LoggerFactory;
 import org.ietf.jgss.*;
 import org.json.*;
 
+import uk.co.amrc.factoryplus.Attempt;
+
 public class FPGssServer extends FPGssPrincipal {
     private static final Logger log = LoggerFactory.getLogger(FPGssServer.class);
 
     String principal;
-    //private GSSCredential creds;
+    String keytab;
 
     /** Internal; construct via {@link FPGssProvider}. */
-    public FPGssServer (FPGssProvider provider, String principal, Subject subject)
+    public FPGssServer (FPGssProvider provider, String principal, String keytab)
     {
-        super(provider, subject);
+        super(provider);
         this.principal = principal;
+        this.keytab = keytab;
     }
+
+    protected int getCredUsage () { return GSSCredential.ACCEPT_ONLY; }
 
     public String getPrincipal () { return principal; }
 
-    /** Fetches our credentials.
-     *
-     * This method verifies we can read the supplied keytab.
-     *
-     * @return This, iff successful.
-     */
-    public Optional<FPGssServer> login ()
+    protected LoginContext buildLoginContext (Subject subject)
+        throws LoginException
     {
-        return Optional.of(this);
-
-//        return withSubject("getting creds from keytab", () -> {
-//
-//            log.info("Got GSS creds for server:");
-//            for (Oid mech : creds.getMechs()) {
-//                log.info("  Oid {}, name {}", 
-//                    mech, creds.getName(mech));
-//            }
-//
-//            return this;
-//        });
+        Configuration config = new KrbConfiguration(principal, keytab);
+        CallbackHandler cb = new NullCallbackHandler();
+        log.info("Creating server context: {}, {}", principal, keytab);
+        return new LoginContext("server", subject, cb, config);
     }
 
     /** Creates a GSS context.
      *
      * @return A new GSS acceptor context.
      */
-    public Optional<GSSContext> createContext ()
+    public Attempt<GSSContext> createContext ()
     {
-        return withSubject("creating server context", () -> {
-            GSSManager mgr = provider.getGSSManager();
-            GSSCredential creds = mgr
-                .createCredential(GSSCredential.ACCEPT_ONLY);
-            return mgr.createContext(creds);
+        return withCreds(creds -> {
+            var krb5 = provider.krb5Mech();
+            log.info("Server creds: {}", creds.getName(krb5));
+            return provider.getGSSManager().createContext(creds);
         });
     }
 }

--- a/src/main/java/uk/co/amrc/factoryplus/gss/KrbConfiguration.java
+++ b/src/main/java/uk/co/amrc/factoryplus/gss/KrbConfiguration.java
@@ -51,6 +51,15 @@ class KrbConfiguration extends Configuration {
             opts.put("useTicketCache", "true");
             break;
 
+        case "client-keytab":
+            opts.put("doNotPrompt", "true");
+            opts.put("storeKey", "true");
+            opts.put("isInitiator", "true");
+            opts.put("principal", principal);
+            opts.put("useKeyTab", "true");
+            opts.put("keyTab", keytab);
+            break;
+
         default:
             return null;
         }

--- a/src/main/java/uk/co/amrc/factoryplus/gss/KrbConfiguration.java
+++ b/src/main/java/uk/co/amrc/factoryplus/gss/KrbConfiguration.java
@@ -40,7 +40,7 @@ class KrbConfiguration extends Configuration {
 
         case "client-password":
             opts.put("doNotPrompt", "false");
-            opts.put("storeKey", "true");
+            opts.put("storeKey", "false");
             opts.put("isInitiator", "true");
             break;
 
@@ -53,7 +53,7 @@ class KrbConfiguration extends Configuration {
 
         case "client-keytab":
             opts.put("doNotPrompt", "true");
-            opts.put("storeKey", "true");
+            opts.put("storeKey", "false");
             opts.put("isInitiator", "true");
             opts.put("principal", principal);
             opts.put("useKeyTab", "true");

--- a/src/main/java/uk/co/amrc/factoryplus/hivemq_auth_krb/FPKrbAuth.java
+++ b/src/main/java/uk/co/amrc/factoryplus/hivemq_auth_krb/FPKrbAuth.java
@@ -34,6 +34,8 @@ import com.hivemq.extension.sdk.api.packets.connect.*;
 import com.hivemq.extension.sdk.api.packets.general.*;
 import com.hivemq.extension.sdk.api.services.Services;
 
+import uk.co.amrc.factoryplus.Attempt;
+
 public class FPKrbAuth implements EnhancedAuthenticator {
 
     private static final @NotNull Logger log = LoggerFactory.getLogger(FPKrbAuth.class);
@@ -156,9 +158,9 @@ public class FPKrbAuth implements EnhancedAuthenticator {
              * this is just to do the whole GSSAPI dance on the client's
              * behalf. */
             var buf = get_client_gss_proxy(user, passwd_buf);
-            if (buf.isEmpty()) {
+            if (buf.isError()) {
                 log.error("Password authentication failed for {}", 
-                    user.toString());
+                    user.toString(), buf.getError());
                 output.failAuthentication();
                 asyncOutput.resume();
                 return;
@@ -188,51 +190,37 @@ public class FPKrbAuth implements EnhancedAuthenticator {
         });
     }
 
-    private Optional<byte[]> get_client_gss_proxy (
+    private Attempt<byte[]> get_client_gss_proxy (
         String user, char[] passwd_buf)
     {
         return provider.createProxyContext(user, passwd_buf)
-            .flatMap(ctx -> {
-                try {
-                    return Optional.of(ctx.initSecContext(new byte[0], 0, 0));
-                }
-                catch (GSSException e) {
-                    log.error("GSS error for client proxy", e.toString());
-                    return Optional.<byte[]>empty();
-                }
-            });
+            .map(ctx -> ctx.initSecContext(new byte[0], 0, 0));
     }
 
     private Single<AuthResult> verify_gssapi (byte[] in_buf)
     {
-        GSSContext ctx = provider.createServerContext();
+        return provider.createServerContext()
+            .toSingle()
+            .flatMap(ctx -> {
+                /* It would be helpful to log the client and server
+                 * identities if this call fails, so we can see who was
+                 * trying to connect and what endpoint they were trying to
+                 * connect to. But get{Src,Targ}Name can't be called until
+                 * the context is established, so we can't. Grrr. */
+                var out_buf = ctx.acceptSecContext(in_buf, 0, in_buf.length);
 
-        try {
-            /* It would be helpful to log the client and server
-             * identities if this call fails, so we can see who was
-             * trying to connect and what endpoint they were trying to
-             * connect to. But get{Src,Targ}Name can't be called until
-             * the context is established, so we can't. Grrr. */
-            byte[] out_buf = ctx.acceptSecContext(in_buf, 0, in_buf.length);
+                /* We could handle this case, but I don't think with the
+                 * Kerberos mech there is ever any need. */
+                if (!ctx.isEstablished())
+                    return Single.<AuthResult>error(
+                        new Exception("GSS login took more than one step!"));
 
-            if (ctx.isEstablished()) {
                 String client_name = ctx.getSrcName().toString();
                 log.info("Authenticated client {}", client_name);
                 return provider.getACLforPrincipal(client_name)
                     .map(acl -> new AuthResult(out_buf, acl))
                     .doOnSuccess(rv -> log.info("MQTT ACL [{}]: {}", 
                         client_name, rv.showACL()));
-            }
-            else {
-                /* We could handle this case, but I don't think with the
-                 * Kerberos mech there is ever any need. */
-                return Single.<AuthResult>error(
-                    new Exception("GSS login took more than one step!"));
-            }
-        }
-        catch (GSSException e) {
-            return Single.<AuthResult>error(
-                new Exception("GSS login failed", e));
-        }
+            });
     }
 }

--- a/src/main/java/uk/co/amrc/factoryplus/hivemq_auth_krb/FPKrbAuthProvider.java
+++ b/src/main/java/uk/co/amrc/factoryplus/hivemq_auth_krb/FPKrbAuthProvider.java
@@ -87,21 +87,17 @@ public class FPKrbAuthProvider implements EnhancedAuthenticatorProvider
         return new FPKrbAuth(this);
     }
 
-    public GSSContext createServerContext ()
+    public Attempt<GSSContext> createServerContext ()
     {
-        return fplus.gssServer()
-            .createContext()
-            .orElseThrow(() -> new ServiceConfigurationError(
-                "Cannot create server GSS context"));
+        return fplus.gssServer().createContext();
     }
 
-    public Optional<GSSContext> createProxyContext (String user, char[] passwd)
+    public Attempt<GSSContext> createProxyContext (String user, char[] passwd)
     {
         String srv = fplus.gssServer().getPrincipal();
         return fplus.gss()
             .clientWithPassword(user, passwd)
-            .flatMap(cli -> cli.login())
-            .flatMap(cli -> cli.createContext(srv));
+            .createContext(srv);
     }
 
     public Single<List<TopicPermission>> getACLforPrincipal (String principal)

--- a/src/main/java/uk/co/amrc/factoryplus/hivemq_auth_krb/FPKrbAuthProvider.java
+++ b/src/main/java/uk/co/amrc/factoryplus/hivemq_auth_krb/FPKrbAuthProvider.java
@@ -94,7 +94,7 @@ public class FPKrbAuthProvider implements EnhancedAuthenticatorProvider
 
     public Attempt<GSSContext> createProxyContext (String user, char[] passwd)
     {
-        String srv = fplus.gssServer().getPrincipal();
+        String srv = fplus.getConf("server_principal");
         return fplus.gss()
             .clientWithPassword(user, passwd)
             .createContext(srv);

--- a/src/main/java/uk/co/amrc/factoryplus/http/FPHttpClient.java
+++ b/src/main/java/uk/co/amrc/factoryplus/http/FPHttpClient.java
@@ -156,13 +156,18 @@ public class FPHttpClient {
     private Single<JsonResponse> fetch (SimpleHttpRequest req)
     {
         //FPThreadUtil.logId("fetch called");
-        //final var context = HttpCacheContext.create();
+        final var context = HttpCacheContext.create();
         return Single.<SimpleHttpResponse>create(obs ->
-                async_client.execute(req, //context,
+                async_client.execute(req, context,
                     new FutureCallback<SimpleHttpResponse>() {
                         public void completed (SimpleHttpResponse res) {
                             //FPThreadUtil.logId("fetch success");
-                            //context.getCacheResponseStatus(),
+                            String uri = "???";
+                            try { uri = req.getUri().toString(); }
+                            catch (Exception e) { }
+                            log.info("Cache {} ({}) for {}",
+                                context.getCacheResponseStatus(),
+                                res.getCode(), uri);
                             obs.onSuccess(res);
                         }
 

--- a/src/main/java/uk/co/amrc/factoryplus/http/FPHttpClient.java
+++ b/src/main/java/uk/co/amrc/factoryplus/http/FPHttpClient.java
@@ -85,6 +85,7 @@ public class FPHttpClient {
             .build();
 
         async_client = CachingHttpAsyncClients.custom()
+            .setCacheConfig(cache_config)
             .setIOReactorConfig(ioReactorConfig)
             .build();
     }

--- a/src/main/java/uk/co/amrc/factoryplus/http/FPHttpClient.java
+++ b/src/main/java/uk/co/amrc/factoryplus/http/FPHttpClient.java
@@ -135,12 +135,12 @@ public class FPHttpClient {
     /** Internal */
     public Single<String> tokenFor (URI service)
     {
-        return Single.fromCallable(() -> {
+        return Single.fromSupplier(() -> {
                 //FPThreadUtil.logId("getting gss context");
                 /* blocking */
                 return fplus.gssClient()
                     .createContextHB("HTTP@" + service.getHost())
-                    .orElseThrow(() -> new Exception("Can't get GSS context"));
+                    .orElseThrow();
             })
             .map(ctx -> new TokenRequest(service, ctx))
                 /* buildRequest is blocking */

--- a/src/main/java/uk/co/amrc/factoryplus/http/ResolvedRequest.java
+++ b/src/main/java/uk/co/amrc/factoryplus/http/ResolvedRequest.java
@@ -35,9 +35,9 @@ class ResolvedRequest
     {
         URI uri = base.resolve(source.path);
 
-        //log.info("Making request {} {}", source.method, uri);
+        log.debug("Making request {} {}", source.method, uri);
         var end = token.length() > 5 ? 5 : token.length();
-        //log.info("Using bearer auth {}...", token.substring(0, end));
+        log.debug("Using bearer auth {}...", token.substring(0, end));
 
         var req = new SimpleHttpRequest(source.method, uri);
         req.setHeader("Authorization", "Bearer " + token);


### PR DESCRIPTION
The Java GSS library doesn't really want to use an external ccache. Unlike the MIT library, which will pull service tickets into a file-based ccache and will use an updated TGT if k5start puts one there, the Java library entirely uses an internal memory ccache. It will initially pull a TGT from a file ccache but won't keep it up to date.

Give the Java code access to its keytab, and get our own TGT. Ensure we have up-to-date credentials and redo the login process (which fetches a new TGT) if our ticket has expired.