### PR TITLE
Robustness updates

### DIFF
--- a/src/main/java/uk/co/amrc/factoryplus/FPAuth.java
+++ b/src/main/java/uk/co/amrc/factoryplus/FPAuth.java
@@ -67,10 +67,8 @@ public class FPAuth {
             .fetch()
             .map(res -> res.ifOk()
                 .flatMap(r -> r.getBodyArray())
-                .orElseGet(() -> {
-                    log.error("Can't fetch ACL: {}", res.getCode());
-                    return new JSONArray();
-                }))
+                .orElseThrow(() -> new FPServiceException(SERVICE, 
+                    res.getCode(), "Can't fetch ACL")))
             .doOnSuccess(acl -> log.info("F+ ACL [{}]: {}", princ, acl))
             .map(acl -> acl.toList().stream()
                 .filter(o -> o instanceof Map)

--- a/src/main/java/uk/co/amrc/factoryplus/FPConfigDB.java
+++ b/src/main/java/uk/co/amrc/factoryplus/FPConfigDB.java
@@ -66,7 +66,7 @@ public class FPConfigDB {
             .fetch()
             .map(res -> res.ifOk()
                 .flatMap(r -> r.getBodyObject())
-                .orElseThrow(() ->
-                    new Exception("ConfigDB entry not an object")));
+                .orElseThrow(() -> new FPServiceException(SERVICE,
+                    res.getCode(), "Can't fetch ConfigDB entry")));
     }
 }

--- a/src/main/java/uk/co/amrc/factoryplus/FPServiceException.java
+++ b/src/main/java/uk/co/amrc/factoryplus/FPServiceException.java
@@ -1,0 +1,48 @@
+/* Factory+ Java client library.
+ * Service exception class.
+ * Copyright 2024 AMRC.
+ */
+
+package uk.co.amrc.factoryplus;
+
+import java.util.UUID;
+
+public class FPServiceException extends Exception
+{
+    private UUID service;
+    private int status;
+
+    public FPServiceException (UUID service, int status, String message)
+    { 
+        super(message);
+        this.service = service;
+        this.status = status;
+    }
+
+    public FPServiceException (UUID service, String message)
+    {
+        this(service, 0, message);
+    }
+
+    public UUID getService () { return service; }
+    public int getStatus () { return status; }
+
+    public String getMessage () {
+        String msg = super.getMessage();
+        if (status == 0)
+            return String.format("[%s] %s", this.service, msg);
+        else
+            return String.format("[%s] (%d) %s", this.service, this.status, msg);
+    }
+
+    public boolean hasService (UUID service) { return this.service == service; }
+    public boolean hasStatus (int status) { return this.status == status; }
+
+    public static boolean check (Throwable err, UUID service, int status)
+    {
+        if (!(err instanceof FPServiceException))
+            return false;
+        var sverr = (FPServiceException)err;
+        return sverr.hasService(service) && sverr.hasStatus(status);
+    }
+}

--- a/src/main/java/uk/co/amrc/factoryplus/hivemq_auth_krb/FPKrbAuthProvider.java
+++ b/src/main/java/uk/co/amrc/factoryplus/hivemq_auth_krb/FPKrbAuthProvider.java
@@ -73,7 +73,6 @@ public class FPKrbAuthProvider implements EnhancedAuthenticatorProvider
                     log.info("Retrying registration in 5 seconds.");
                 })
                 .delay(5, TimeUnit.SECONDS))
-            .timeout(10, TimeUnit.MINUTES)
             .subscribe(() -> log.info("Registered service successfully"),
                 e -> log.error("Failed to register service: {}", 
                     e.toString()));


### PR DESCRIPTION
* Don't stop trying to register our service. Timing out in this situation isn't helpful.
* Fail authentication if we can't contact the upstream services.

Returning a Service Unavailable code would be better than failing authentication, but that would require more restructuring of the code. At least like this we don't get clients successfully connected with the wrong ACLs.